### PR TITLE
Use explicit type to help the Scala compiler

### DIFF
--- a/app/states/State.scala
+++ b/app/states/State.scala
@@ -11,6 +11,6 @@ object Board{
   sealed trait Status
   case object Running extends Status
   case object Archived extends Status
-  implicit val statusF  = derived.flat.oformat[Board.Status]((__ \ "type").format[String])
-  implicit val format = Json.format[Board]
+  implicit val statusF: OFormat[Status] = derived.flat.oformat[Board.Status]((__ \ "type").format[String])
+  implicit val format: OFormat[Board] = Json.format[Board]
 }


### PR DESCRIPTION
Otherwise the following compilation error can be thrown by the compiler:

```
java.util.NoSuchElementException: value inst$macro$29
	at scala.collection.mutable.AnyRefMap$ExceptionDefault.apply(AnyRefMap.scala:425)
	at scala.collection.mutable.AnyRefMap$ExceptionDefault.apply(AnyRefMap.scala:424)
	at scala.collection.mutable.AnyRefMap.apply(AnyRefMap.scala:180)
	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder$locals$.load(BCodeSkelBuilder.scala:390)
	at scala.tools.nsc.backend.jvm.BCodeBodyBuilder$PlainBodyBuilder.genLoad(BCodeBodyBuilder.scala:354)
	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.emitNormalMethodBody$1(BCodeSkelBuilder.scala:602)
	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.genDefDef(BCodeSkelBuilder.scala:634)
	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.gen(BCodeSkelBuilder.scala:508)
	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.$anonfun$gen$7(BCodeSkelBuilder.scala:510)
	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.gen(BCodeSkelBuilder.scala:510)
	at scala.tools.nsc.backend.jvm.BCodeSkelBuilder$PlainSkelBuilder.genPlainClass(BCodeSkelBuilder.scala:110)
	at scala.tools.nsc.backend.jvm.CodeGen.genClass(CodeGen.scala:69)
	at scala.tools.nsc.backend.jvm.CodeGen.genClassDef$1(CodeGen.scala:31)
	at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$3(CodeGen.scala:54)
	at scala.tools.nsc.backend.jvm.CodeGen.genClassDefs$1(CodeGen.scala:54)
	at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$2(CodeGen.scala:53)
	at scala.tools.nsc.backend.jvm.CodeGen.genClassDefs$1(CodeGen.scala:53)
	at scala.tools.nsc.backend.jvm.CodeGen.$anonfun$genUnit$4(CodeGen.scala:58)
	at scala.tools.nsc.backend.jvm.CodeGen.genUnit(CodeGen.scala:58)
	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.apply(GenBCode.scala:67)
	at scala.tools.nsc.Global$GlobalPhase.$anonfun$applyPhase$1(Global.scala:426)
	at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:419)
	at scala.tools.nsc.Global$GlobalPhase.$anonfun$run$1(Global.scala:390)
	at scala.tools.nsc.Global$GlobalPhase.$anonfun$run$1$adapted(Global.scala:390)
	at scala.collection.Iterator.foreach(Iterator.scala:944)
	at scala.collection.Iterator.foreach$(Iterator.scala:944)
	at scala.collection.AbstractIterator.foreach(Iterator.scala:1432)
	at scala.tools.nsc.Global$GlobalPhase.run(Global.scala:390)
	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.super$run(GenBCode.scala:73)
	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.$anonfun$run$1(GenBCode.scala:73)
	at scala.tools.nsc.backend.jvm.GenBCode$BCodePhase.run(GenBCode.scala:71)
	at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1446)
	at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1430)
	at scala.tools.nsc.Global$Run.compileSources(Global.scala:1423)
	at scala.tools.nsc.Global$Run.compile(Global.scala:1539)
	at xsbt.CachedCompiler0.run(CompilerInterface.scala:130)
	at xsbt.CachedCompiler0.run(CompilerInterface.scala:105)
	at xsbt.CompilerInterface.run(CompilerInterface.scala:31)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at sbt.internal.inc.AnalyzingCompiler.call(AnalyzingCompiler.scala:237)
	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:111)
	at sbt.internal.inc.AnalyzingCompiler.compile(AnalyzingCompiler.scala:90)
	at sbt.internal.inc.MixedAnalyzingCompiler.$anonfun$compile$3(MixedAnalyzingCompiler.scala:83)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:12)
	at sbt.internal.inc.MixedAnalyzingCompiler.timed(MixedAnalyzingCompiler.scala:134)
	at sbt.internal.inc.MixedAnalyzingCompiler.compileScala$1(MixedAnalyzingCompiler.scala:74)
	at sbt.internal.inc.MixedAnalyzingCompiler.compile(MixedAnalyzingCompiler.scala:117)
	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1(IncrementalCompilerImpl.scala:305)
	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileInternal$1$adapted(IncrementalCompilerImpl.scala:305)
	at sbt.internal.inc.Incremental$.doCompile(Incremental.scala:101)
	at sbt.internal.inc.Incremental$.$anonfun$compile$4(Incremental.scala:82)
	at sbt.internal.inc.IncrementalCommon.recompileClasses(IncrementalCommon.scala:110)
	at sbt.internal.inc.IncrementalCommon.cycle(IncrementalCommon.scala:57)
	at sbt.internal.inc.Incremental$.$anonfun$compile$3(Incremental.scala:84)
	at sbt.internal.inc.Incremental$.manageClassfiles(Incremental.scala:129)
	at sbt.internal.inc.Incremental$.compile(Incremental.scala:75)
	at sbt.internal.inc.IncrementalCompile$.apply(Compile.scala:61)
	at sbt.internal.inc.IncrementalCompilerImpl.compileInternal(IncrementalCompilerImpl.scala:309)
	at sbt.internal.inc.IncrementalCompilerImpl.$anonfun$compileIncrementally$1(IncrementalCompilerImpl.scala:267)
	at sbt.internal.inc.IncrementalCompilerImpl.handleCompilationError(IncrementalCompilerImpl.scala:158)
	at sbt.internal.inc.IncrementalCompilerImpl.compileIncrementally(IncrementalCompilerImpl.scala:237)
	at sbt.internal.inc.IncrementalCompilerImpl.compile(IncrementalCompilerImpl.scala:68)
	at sbt.Defaults$.compileIncrementalTaskImpl(Defaults.scala:1443)
	at sbt.Defaults$.$anonfun$compileIncrementalTask$1(Defaults.scala:1417)
	at scala.Function1.$anonfun$compose$1(Function1.scala:44)
	at sbt.internal.util.$tilde$greater.$anonfun$$u2219$1(TypeFunctions.scala:39)
	at sbt.std.Transform$$anon$4.work(System.scala:66)
	at sbt.Execute.$anonfun$submit$2(Execute.scala:263)
	at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:16)
	at sbt.Execute.work(Execute.scala:272)
	at sbt.Execute.$anonfun$submit$1(Execute.scala:263)
	at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:174)
	at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
[error] Error while emitting State.scala
[error] value inst$macro$29
[error] one error found
[error] (Compile / compileIncremental) Compilation failed
[error] Total time: 14 s, completed 28 oct. 2018 17:07:23
```